### PR TITLE
fixes some hasty mistakes in scrape_gps

### DIFF
--- a/lib/tasks/scrape_gps.rake
+++ b/lib/tasks/scrape_gps.rake
@@ -13,18 +13,22 @@ namespace :app do
             nat = player.nationality
 
             if (pob.include? " ")
-                pob = player.place_of_birth.gsub!(" ","+")
+                pob = player.place_of_birth.gsub(" ","+")
             end
 
             if (player.nationality.include? " ")
-                nat = player.nationality.gsub!(" ","+")
+                nat = player.nationality.gsub(" ","+")
             end
 
-            query = url_base + "address=" + player.place_of_birth + ",+" + player.nationality + "&" + "AIzaSyCtNLoBlmw1b1zUJa10PSXqHu-QII9NpYU"
+            query = url_base + "address=" + pob + ",+" + nat + "&" + "AIzaSyCtNLoBlmw1b1zUJa10PSXqHu-QII9NpYU"
 
             response = HTTParty.get(URI.encode(query))
 
             location = JSON.parse(response.body)['results'][0]['geometry']['location'] #testing
+
+            if (location == nil)
+                next
+            end
 
             player.write_attribute(:bp_latitude,location['lat'])
             player.write_attribute(:bp_longitude,location['lng'])

--- a/lib/tasks/scrape_player_place_of_birth.rake
+++ b/lib/tasks/scrape_player_place_of_birth.rake
@@ -32,7 +32,7 @@ namespace :app do
 				player.save!
 			end
 
-			puts "Number of players birthplaces updated: #{i + 1}" 
+			print "\rNumber of players birthplaces updated: #{i + 1}" 
 		end
 
 		finish = Time.now


### PR DESCRIPTION
scrape_gps was replacing whitespace in place, fixed with "gsub" instead of "gsub!"  closes #41
"pob" and "nat" variables weren't in use

scrape_ppob now overwrites terminal output in place closes #42 